### PR TITLE
Change updateSlider (undefined) to slider

### DIFF
--- a/src/angular-ui-nouislider.js
+++ b/src/angular-ui-nouislider.js
@@ -91,7 +91,7 @@ angular.module('ui.nouislider', []).directive('nouiSlider', function() {
 
                     // merge changes into the options object and recreate the slider
                     angular.merge(options, newOptions);
-                    noUiSlider.create(updateSlider, options);
+                    noUiSlider.create(slider, options);
                     slider.noUiSlider.on('slide', onUpdate);
                 }
             });


### PR DESCRIPTION
I didn't find updateSlider referenced anywhere--perhaps you wanted to create a new DOM-tracking variable with that name. Plunker kept throwing errors because it wasn't defined, so I updated the file like so, and voila!
